### PR TITLE
Fix: correct typo in post about scroll optimization

### DIFF
--- a/content/blog/web/optimize-scroll-event.md
+++ b/content/blog/web/optimize-scroll-event.md
@@ -9,7 +9,7 @@ category: web
 우리는 아래처럼 브라우저의 스크롤에 이벤트를 추가할 수 있습니다.
 
 ```js
-window.addEventListenr('scroll', onScroll)
+window.addEventListener('scroll', onScroll)
 ```
 
 `onScroll` 함수에 `console.log('scrolled')` 를 추가해보겠습니다.
@@ -95,7 +95,7 @@ window.addEventListener('scroll', toFit(onScroll))
 
 바로 `onScroll`을 이벤트에 등록하지 않고 `toFit`으로 한 번 감싸줬습니다. 지금부터 이 `toFit` util이 하는 일에 대해 알아보겠습니다.
 
-## What happend?
+## What happened?
 
 간소화 된 형태를 먼저 살펴보겠습니다.
 
@@ -138,7 +138,7 @@ export function toFitSimple(cb) {
 
 실제로 호출되어야 하는 `cb`가 `rAF`에 의해 비동기로 처리되고 `tick`에 의해 브라우저 렌더링 범위 내에서 animation frame에 들어가게 되므로 스크롤 이벤트를 최적화 할 수 있습니다.
 
-> `toFit`은 이 `toFitSimple`에 triggr 조건과 dismiss 조건을 추가한 함수일 뿐 입니다.
+> `toFit`은 이 `toFitSimple`에 trigger 조건과 dismiss 조건을 추가한 함수일 뿐 입니다.
 
 ## Passive Event
 


### PR DESCRIPTION
안녕하세요. [스크롤 이벤트 최적화](https://jbee.io/web/optimize-scroll-event/) 글 잘 읽었습니다! 오타 몇 개를 발견해서 PR 올려요. 👍👍👍
아, 그리고 내용과 관련해서 궁금한 것이 하나 생겼는데, 혹시 힌트를 주실 수 있을까 해서 여쭤보고 싶습니다 ㅎㅎ

재엽님께서 쓰신 글과 함께 Google Developers Web에 있는 [Improving Scroll Performance with Passive Event Listeners](https://developers.google.com/web/updates/2016/06/passive-event-listeners) 의 내용을 같이 읽어봤었는데요.

> Note: The basic `scroll` event cannot be canceled, so it does not need to be set passive. However, you should still [prevent expensive work](https://developer.mozilla.org/en-US/docs/Web/API/Document/scroll_event#scroll_event_throttling) from being completed in the handler.

맨 위에 **스크롤 이벤트는 취소될 수 없으므로 passive 속성을 설정할 필요가 없다**고 나옵니다(여기서 prevent expensive work은 [주어진 링크](https://developer.mozilla.org/en-US/docs/Web/API/Document/scroll_event#scroll_event_throttling)로 보건데, 재엽님께서 작성하신 글처럼 _throttling을 구현해라~_ 하는 뜻으로 보입니다).

> You don't need to worry about the value of passive for the basic `scroll` event. Since it can't be canceled, event listeners can't block page rendering anyway.

[Mozilla 문서](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#improving_scrolling_performance_with_passive_listeners)에서도 같은 내용이 적혀 있습니다.

이러한 **취소될 수 없는 이벤트**에는 `scroll` 말고도 `resize` 등이 있을 것 같은데요. 이들의 이벤트 핸들러에는 `passive` 속성을 지정하지 않아도 `event.preventDefault`가 감시되지 않는 것인지 궁금합니다. 🙏 